### PR TITLE
Do not hardcode --all-ramdisk-modules and --firmware options to genkernel

### DIFF
--- a/buildkernel
+++ b/buildkernel
@@ -1699,7 +1699,7 @@ create_initramfs_using_genkernel() {
     genkernel --install --no-mountboot \
         --luks --lvm  --no-gpg --udev ${POSTCLEAR_FLAG} \
         --kernel-config="${TARGETCONFIG}" --busybox \
-        --no-compress-initramfs --all-ramdisk-modules --firmware \
+        --no-compress-initramfs \
         ${PLYMOUTH_OPTS} initramfs
     cp ${VERBOSITYFLAG} "${BOOTDIR}/${INITRAMFSNAME}" "${UNCOMPRESSEDINITRAMFS}"
 }


### PR DESCRIPTION
This PR removes the `--all-ramdisk-modules` and `--firmware` options from the genkernel call. Without these options the user is able to fine-tune his initrd via genkernel.conf.

This has been tested against a NIB Lenovo X1 Yoga with a 256MB EFI partition.

Fixes [Issue 4](https://github.com/sakaki-/buildkernel/issues/4).
