### PR TITLE
add fs-type in conf

### DIFF
--- a/buildkernel
+++ b/buildkernel
@@ -457,6 +457,10 @@ setup_final_variables() {
     # has been set explicitly in buildkernel.conf
     KEYFILEPARTUUID="${KEYFILEPARTUUID:-${EFIPARTUUID}}"
     KEYFILEPATHMAP="${PARTUUIDDEVDIR}/${KEYFILEPARTUUID}"
+    # set/update CMDLINE_ROOTFSTYPE to actual FS type if not defined in buildkernel.conf
+    if [ -z ${ROOTFILESYSTEMTYPE+xxx} ]; then
+        CMDLINE_ROOTFSTYPE="$(cut -d\" -f2 <<< $(cut -d' ' -f4 <<< $(/sbin/blkid -t LABEL=root)))"
+    fi
     # we use path syntax rather than "=PARTUUID=" syntax, as more reliable
     KERNEL_CMD_LINE="root=${CMDLINE_ROOT} crypt_root=${CRYPTPATHMAP} dolvm "
     KERNEL_CMD_LINE+="real_root=${CMDLINE_REAL_ROOT} rootfstype=${CMDLINE_ROOTFSTYPE} "

--- a/buildkernel
+++ b/buildkernel
@@ -72,9 +72,9 @@ SECUREBOOTCERT="/etc/efikeys/db.crt"
 SIGNEDSUFFIX=".signed"
 ADDITIONALKERNELCMDS=""
 ADDITIONALGENKERNELOPTS="--all-ramdisk-modules --firmware"
-CMDLINE_ROOTFSTYPE="ext4"
 CMDLINE_REAL_ROOT="/dev/mapper/vg1-root"
 CMDLINE_REAL_RESUME="/dev/mapper/vg1-swap"
+CMDLINE_ROOTFSTYPE="$(/bin/findmnt -n -o FSTYPE -S ${CMDLINE_REAL_ROOT})"
 declare -i DEFAULTCREATEEFIBOOT=1
 declare -i CREATEEFIBOOT="${DEFAULTCREATEEFIBOOT}"
 declare -i DEFAULTCOMPRESSINITRAMFS=1
@@ -457,10 +457,6 @@ setup_final_variables() {
     # has been set explicitly in buildkernel.conf
     KEYFILEPARTUUID="${KEYFILEPARTUUID:-${EFIPARTUUID}}"
     KEYFILEPATHMAP="${PARTUUIDDEVDIR}/${KEYFILEPARTUUID}"
-    # set/update CMDLINE_ROOTFSTYPE to actual FS type if not defined in buildkernel.conf
-    if [ -z ${ROOTFILESYSTEMTYPE+xxx} ]; then
-        CMDLINE_ROOTFSTYPE="$(cut -d\" -f2 <<< $(cut -d' ' -f4 <<< $(/sbin/blkid -t LABEL=root)))"
-    fi
     # we use path syntax rather than "=PARTUUID=" syntax, as more reliable
     KERNEL_CMD_LINE="root=${CMDLINE_ROOT} crypt_root=${CRYPTPATHMAP} dolvm "
     KERNEL_CMD_LINE+="real_root=${CMDLINE_REAL_ROOT} rootfstype=${CMDLINE_ROOTFSTYPE} "

--- a/buildkernel
+++ b/buildkernel
@@ -74,7 +74,6 @@ ADDITIONALKERNELCMDS=""
 ADDITIONALGENKERNELOPTS="--all-ramdisk-modules --firmware"
 CMDLINE_REAL_ROOT="/dev/mapper/vg1-root"
 CMDLINE_REAL_RESUME="/dev/mapper/vg1-swap"
-CMDLINE_ROOTFSTYPE="$(/bin/findmnt -n -o FSTYPE -S ${CMDLINE_REAL_ROOT})"
 declare -i DEFAULTCREATEEFIBOOT=1
 declare -i CREATEEFIBOOT="${DEFAULTCREATEEFIBOOT}"
 declare -i DEFAULTCOMPRESSINITRAMFS=1
@@ -457,6 +456,10 @@ setup_final_variables() {
     # has been set explicitly in buildkernel.conf
     KEYFILEPARTUUID="${KEYFILEPARTUUID:-${EFIPARTUUID}}"
     KEYFILEPATHMAP="${PARTUUIDDEVDIR}/${KEYFILEPARTUUID}"
+    # get the real root filesystem type
+    if [[ ! -v CMDLINE_ROOTFSTYPE ]]; then
+        CMDLINE_ROOTFSTYPE="$(/bin/findmnt -n -o FSTYPE -S ${CMDLINE_REAL_ROOT})"
+    fi
     # we use path syntax rather than "=PARTUUID=" syntax, as more reliable
     KERNEL_CMD_LINE="root=${CMDLINE_ROOT} crypt_root=${CRYPTPATHMAP} dolvm "
     KERNEL_CMD_LINE+="real_root=${CMDLINE_REAL_ROOT} rootfstype=${CMDLINE_ROOTFSTYPE} "

--- a/buildkernel.conf
+++ b/buildkernel.conf
@@ -79,6 +79,10 @@
 # uncompressed ramfs, even though the enclosing kernel is itself compressed
 #COMPRESSINITRAMFS=0
 
+# you can manually set the filesystem type for your root partition here.
+# however, doing so should not be necessary.
+#CMDLINE_ROOTFSTYPE="ext4"
+
 # if you need to conform the config file for some reason, uncomment this
 # hook function and fill it out to suit your requirements
 # NB you should only really need to do this to override a setting forced

--- a/buildkernel.conf
+++ b/buildkernel.conf
@@ -21,11 +21,6 @@
 # contents of CRYPTPARTUUID will be ignored
 #CRYPTPATHMAP="/dev/disk/by-uuid/01234567-89ab-cdef-0123-456789abcdef"
 
-# if using a root-filesystem other than ext4, set it here.
-# buildkernel will attempt to set the correct filesystem type automatically if
-# this variable is not set manually. Default is ext4.
-# ROOTFILESYSTEMTYPE="ext4"
-
 # if your LUKS keyfile is not on your EFI system partition (for example,
 # because you use a USB key to hold the keyfile, but have created an EFI
 # system partition on the machine's main drive), then uncomment the below

--- a/buildkernel.conf
+++ b/buildkernel.conf
@@ -21,6 +21,11 @@
 # contents of CRYPTPARTUUID will be ignored
 #CRYPTPATHMAP="/dev/disk/by-uuid/01234567-89ab-cdef-0123-456789abcdef"
 
+# if using a root-filesystem other than ext4, set it here.
+# buildkernel will attempt to set the correct filesystem type automatically if
+# this variable is not set manually. Default is ext4.
+# ROOTFILESYSTEMTYPE="ext4"
+
 # if your LUKS keyfile is not on your EFI system partition (for example,
 # because you use a USB key to hold the keyfile, but have created an EFI
 # system partition on the machine's main drive), then uncomment the below


### PR DESCRIPTION
Originally created my install with XFS filesystem types. Couldn't find a config option anywhere so after poking around in buildkernel and seeing ext4 hardcoded in, I decided to add an option in buildkernel.conf for alternative filesystem types and absent that variable in buildkernel.conf, get the actual filesystem type of the root labelled partition using blkid in the final variable setup function of buildkernel.