### PR TITLE
Add support for automatically signing external modules

### DIFF
--- a/buildkernel
+++ b/buildkernel
@@ -436,10 +436,10 @@ source_etc_conf_file() {
             KERNEL_SIGNING_CERT="${LINUXDIR}/certs/signing_key.x509"
             KERNEL_SIGNING_KEY="${LINUXDIR}/certs/signing_key.pem"
         else
-            if [[ ! -f KERNEL_SIGNING_CERT ]]; then
+            if [[ ! -f "${KERNEL_SIGNING_CERT}" ]]; then
                 die "Cannot proceed; KERNEL_SIGNING_CERT is not a valid path to a file."
             fi
-            if [[ ! -f KERNEL_SIGNING_KEY ]]; then
+            if [[ ! -f "${KERNEL_SIGNING_KEY}" ]]; then
                 die "Cannot proceed; KERNEL_SIGNING_KEY is not a valid path to a file."
             fi
         fi

--- a/buildkernel
+++ b/buildkernel
@@ -109,6 +109,7 @@ GPGBUILDDIR="/root/tmpgpgbuild"
 TMPGPGPATH="${GPGBUILDDIR}/usr/bin/gpg"
 declare -i USINGUSBKEYFOREFI=0
 declare -i BACKUPOLDKERNEL=1
+declare -i BUILT_EXTERNAL_MODULES=1
 
 EFIPARTNAME="EFI boot partition"
 DEFAULTKEYMAP="us"
@@ -422,6 +423,29 @@ source_etc_conf_file() {
     # map INITSYSTEM to lower case
     if [[ -v INITSYSTEM ]]; then
         INITSYSTEM="${INITSYSTEM,,}"
+    fi
+    # perform checks on KERNEL_SIGNING_CERT and KERNEL_SIGNING_KEY
+    if [[ -v KERNEL_SIGNING_CERT ]]; then
+        if [[ ! -v KERNEL_SIGNING_KEY ]]; then
+            die "Cannot proceed; KERNEL_SIGNING_CERT is configured, but KERNEL_SIGNING_KEY is not."
+        fi
+        if [[ "${KERNEL_SIGNING_CERT}" == "auto" || "${KERNEL_SIGNING_KEY}" == "auto" ]]; then
+            if [[ "${KERNEL_SIGNING_CERT}" != "${KERNEL_SIGNING_KEY}" ]]; then
+                die "Cannot proceed; in automatic external module signing mode, both KERNEL_SIGNING_CERT and KERNEL_SIGNING_KEY must be set to \"auto\""
+            fi
+            KERNEL_SIGNING_CERT="${LINUXDIR}/certs/signing_key.x509"
+            KERNEL_SIGNING_KEY="${LINUXDIR}/certs/signing_key.pem"
+        else
+            if [[ ! -f KERNEL_SIGNING_CERT ]]; then
+                die "Cannot proceed; KERNEL_SIGNING_CERT is not a valid path to a file."
+            fi
+            if [[ ! -f KERNEL_SIGNING_KEY ]]; then
+                die "Cannot proceed; KERNEL_SIGNING_KEY is not a valid path to a file."
+            fi
+        fi
+    fi
+    if [[ -v KERNEL_SIGNING_KEY && ! -v KERNEL_SIGNING_CERT ]]; then
+        die "Cannot proceed; KERNEL_SIGNING_KEY is configured, but KERNEL_SIGNING_CERT is not."
     fi
 }
 setup_final_variables() {
@@ -1818,7 +1842,13 @@ rebuild_external_modules_if_necessary() {
             else
                 warning "Failed to complete emerge @module-rebuild due to error"
                 warning "Continuing..."
+                BUILT_EXTERNAL_MODULES=0
             fi
+        fi
+        if [[ ${BUILT_EXTERNAL_MODULES}==1 && -v KERNEL_SIGNING_CERT ]] ; then
+            for EXTERNAL_MODULE in `find /lib/modules/${NEWVERSION#"linux-"}/* -type f -name '*.ko' -not -path '*/kernel/*'`; do
+                "${LINUXDIR}/scripts/sign-file" sha512 "${KERNEL_SIGNING_KEY}" "${KERNEL_SIGNING_CERT}" "${EXTERNAL_MODULE}"
+            done
         fi
     fi
 }

--- a/buildkernel
+++ b/buildkernel
@@ -31,7 +31,7 @@ shopt -s nullglob
 # ********************** variables ********************* 
 PROGNAME="$(basename "${0}")"
 CONFFILE="/etc/${PROGNAME}.conf"
-VERSION="1.0.33"
+VERSION="1.0.34"
 ETCPROFILE="/etc/profile"
 DEFAULTEFIBOOTFILE="bootx64.efi"
 EFIBOOTFILE="${DEFAULTEFIBOOTFILE}"

--- a/buildkernel.8
+++ b/buildkernel.8
@@ -1,4 +1,4 @@
-.TH BUILDKERNEL 8 "Version 1.0.33: October 2018"
+.TH BUILDKERNEL 8 "Version 1.0.34: April 2019"
 .SH NAME
 buildkernel \- build secure boot kernel, save to EFI system partition
 .SH SYNOPSIS

--- a/buildkernel.conf
+++ b/buildkernel.conf
@@ -83,6 +83,14 @@
 # however, doing so should not be necessary.
 #CMDLINE_ROOTFSTYPE="ext4"
 
+# if you sign your kernel modules, configure the signing certificate and key
+# paths to sign external modules as well once built. Setting the variables to
+# "auto" will use the kernel's automatically generated certificate and key if
+# you have configured it to generate them. By default the variable is unset and
+# modules will not be signed.
+#KERNEL_SIGNING_CERT="auto"
+#KERNEL_SIGNING_KEY="auto"
+
 # if you need to conform the config file for some reason, uncomment this
 # hook function and fill it out to suit your requirements
 # NB you should only really need to do this to override a setting forced

--- a/buildkernel.conf.5
+++ b/buildkernel.conf.5
@@ -1,4 +1,4 @@
-.TH BUILDKERNEL 5 "Version 1.0.33: October 2018"
+.TH BUILDKERNEL 5 "Version 1.0.34: April 2019"
 .SH NAME
 buildkernel.conf \- a configuration file for \fBbuildkernel\fR(8)
 .SH SYNOPSIS

--- a/buildkernel.conf.5
+++ b/buildkernel.conf.5
@@ -194,6 +194,26 @@ automatically detect the filesystem type of \fBCMDLINE_REAL_ROOT\fR
 (falling back to \fBext4\fR, in case of error).
 
 Most users will not need to override the default.
+.br
+.TP
+.BR KERNEL_SIGNING_CERT
+If you sign your kernel modules, set this to the path for the signing
+certificate so that your external modules are signed after being built.
+Setting to \fBauto\fR uses the kernel's automatically generated signing
+certificate if you have configured it to generate it.
+
+By default this is not set and causes external modules to not be signed.
+Requires that the \fBKERNEL_SIGNING_KEY\fR variable is set.
+.br
+.TP
+.BR KERNEL_SIGNING_KEY
+If you sign your kernel modules, set this to the path for the signing key so
+that your external modules are signed after being built. Setting to \fBauto\fR
+uses the kernel's automatically generated signing key if you have configured it
+to generate it.
+
+By default this is not set and causes external modules to not be signed.
+Requires that the \fBKERNEL_SIGNING_CERT\fR variable is set.
 
 .RE
 .SH FUNCTIONS


### PR DESCRIPTION
Two new configuration options:
- **KERNEL_SIGNING_CERT**
- **KERNEL_SIGNING_KEY**

Possible values:
- unset
- "_/path/to/key/or/certificate_"
- "auto"