### PR TITLE
Add option to disable Suspend

### DIFF
--- a/buildkernel
+++ b/buildkernel
@@ -31,7 +31,7 @@ shopt -s nullglob
 # ********************** variables ********************* 
 PROGNAME="$(basename "${0}")"
 CONFFILE="/etc/${PROGNAME}.conf"
-VERSION="1.0.35"
+VERSION="1.0.36"
 ETCPROFILE="/etc/profile"
 DEFAULTEFIBOOTFILE="bootx64.efi"
 EFIBOOTFILE="${DEFAULTEFIBOOTFILE}"
@@ -77,6 +77,7 @@ declare -i DEFAULTCREATEEFIBOOT=1
 declare -i CREATEEFIBOOT="${DEFAULTCREATEEFIBOOT}"
 declare -i DEFAULTCOMPRESSINITRAMFS=1
 declare -i COMPRESSINITRAMFS="${DEFAULTCOMPRESSINITRAMFS}"
+declare -i DISABLE_SUSPEND=0
 declare -i DISABLE_HIBERNATION=0
 declare -i DISABLE_LVM=0
 # you can use xconfig etc if you like - override in /etc/buildkernel.conf
@@ -1744,8 +1745,13 @@ conform_config_file() {
     set_kernel_config_list_to_y "RTC_CLASS RTC_HCTOSYS RTC_SYSTOHC"
     set_kernel_config "RTC_HCTOSYS_DEVICE" "rtc0"
     set_kernel_config_list_to_y "RTC_INTF_SYSFS RTC_INTF_PROC RTC_INTF_DEV RTC_DRV_CMOS"
-    show "Enabling suspend support..."
-    set_kernel_config_list_to_y "SUSPEND"
+    if ((DISABLE_SUSPEND==0)); then
+        show "Enabling suspend support..."
+        set_kernel_config_list_to_y "SUSPEND"
+    else
+        show "Disabling suspend support..."
+        unset_kernel_config "SUSPEND"
+    fi
     if ((DISABLE_HIBERNATION==0)); then
         show "Enabling hibernation support..."
         set_kernel_config_list_to_y "HIBERNATION"

--- a/buildkernel.8
+++ b/buildkernel.8
@@ -1,4 +1,4 @@
-.TH BUILDKERNEL 8 "Version 1.0.35: April 2019"
+.TH BUILDKERNEL 8 "Version 1.0.36: February 2020"
 .SH NAME
 buildkernel \- build secure boot kernel, save to EFI system partition
 .SH SYNOPSIS

--- a/buildkernel.conf
+++ b/buildkernel.conf
@@ -91,6 +91,10 @@
 #KERNEL_SIGNING_CERT="auto"
 #KERNEL_SIGNING_KEY="auto"
 
+# if you don't wish to enable suspend, uncomment below. Default is 0
+# (Suspend enabled).
+#DISABLE_SUSPEND=1
+
 # if you don't wish to enable hibernation, uncomment below. Default is 0
 # (Hibernation enabled).
 #DISABLE_HIBERNATION=1

--- a/buildkernel.conf.5
+++ b/buildkernel.conf.5
@@ -1,4 +1,4 @@
-.TH BUILDKERNEL 5 "Version 1.0.35: April 2019"
+.TH BUILDKERNEL 5 "Version 1.0.36: February 2020"
 .SH NAME
 buildkernel.conf \- a configuration file for \fBbuildkernel\fR(8)
 .SH SYNOPSIS
@@ -214,6 +214,11 @@ to generate it.
 
 By default this is not set and causes external modules to not be signed.
 Requires that the \fBKERNEL_SIGNING_CERT\fR variable is set.
+.br
+.TP
+.BR DISABLE_SUSPEND
+If you wish to disable suspend, set this to \fB1\fR. This is set to
+\fB0\fR (Suspend enabled) by default.
 .br
 .TP
 .BR DISABLE_HIBERNATION


### PR DESCRIPTION
Because newer Intel firmware included in-kernel may cause suspend-to-ram to fail (see [wiki page](https://wiki.gentoo.org/wiki/Intel#Kernel)).