### PR TITLE
Don't build gpg if using LUKS passphrase

### DIFF
--- a/buildkernel
+++ b/buildkernel
@@ -1916,16 +1916,18 @@ build_static_gpg() {
     emerge ${VERBOSITYFLAG} "app-crypt/staticgpg"
 }
 modify_initramfs() {
-    if [ ! -x "${GPG1PATHFROM}" ]; then
-        if ((ARG_ASK==1)); then
-            continue_yn "No static gpg found, would you like to build it?"
-        else
-            show "No static gpg found, so creating one..."
+    if [ -n "${LUKSKEYFILE}" ]; then
+        if [ ! -x "${GPG1PATHFROM}" ]; then
+            if ((ARG_ASK==1)); then
+                continue_yn "No static gpg found, would you like to build it?"
+            else
+                show "No static gpg found, so creating one..."
+            fi
+            build_static_gpg
         fi
-        build_static_gpg
+        show "Copying static gpg program into initramfs..."
+        cp ${VERBOSITYFLAG} "${GPG1PATHFROM}" "${GPG1PATHTO}"
     fi
-    show "Copying static gpg program into initramfs..."
-    cp ${VERBOSITYFLAG} "${GPG1PATHFROM}" "${GPG1PATHTO}"
 
     if ((USINGMODULES==1)); then
         show "Copying contents of ${MODPROBEDIR} directory into initramfs..."


### PR DESCRIPTION
If you're not attempting to use a keyfile for LUKS and only use a
passphrase, this skips building the static GPG. This cuts down a lot of
dependencies if you've got no interest in a LUKS keyfile, even if it is
more secure than using a passphrase.

The diff looks like it changed more than it did because of indentation.